### PR TITLE
change base image to postgis/postgis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mdillon/postgis:11-alpine
+FROM postgis/postgis:13-3.1-alpine
 LABEL GeoNode development team
 
 COPY ./initdb-geonode.sh /docker-entrypoint-initdb.d/geonode.sh


### PR DESCRIPTION
Due to the reported security issues around Christmas to the psc mailing list, I'd like to update the PostGIS image.

The used base image [mdillon/postgis](https://hub.docker.com/r/mdillon/postgis/) received its last update over 2 years ago. Further, the named source repository _appropriate/docker-postgis_ now links to the main [PostGIS organization](https://github.com/postgis/docker-postgis) that's why I guess _mdillon/postgis_ is discontinued and `postgis/postgis` can be seen as the successor.

My Pull request sets the latest used base image to `postgis/postgis:13-3.1-alpine`. From a first test (upload layer create and delete map), this works fine.

---
@afabiani @gannebamm 

As a) the base image gets changed and b) two major versions are leveled up, I'm unsure how to sufficiently test this PR. I'm in fear of regressions for example with backup and restore, search by extent, and all other parts which are not covered by tests.

What do you think?
 